### PR TITLE
Do not disable apparmor by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,4 +17,4 @@
 # limitations under the License.
 #
 
-default['apparmor']['disable'] = true
+default['apparmor']['disable'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Disables apparmor service on Ubuntu'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.9.4'
+version '0.9.5'
 supports 'ubuntu'
 recipe 'apparmor::default', 'Disables apparmor service on Ubuntu'
 


### PR DESCRIPTION
No idea why this would be made the default, include_recipe 'apparmor'
doesn't sound like something that would remove apparmor from my systems.

Fixes: https://github.com/chef-cookbooks/apparmor/issues/6