### PR TITLE
Modernize testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,10 @@
-sudo: required
-dist: trusty
-
 addons:
   apt:
     sources:
-      - chef-current-trusty
+      - chef-current-xenial
     packages:
-      - chefdk
+      - chef-workstation
 
-# Don't `bundle install` which takes about 1.5 mins
 install: echo "skip bundle install"
 
 branches:
@@ -26,13 +22,11 @@ before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
   - eval "$(chef shell-init bash)"
   - chef --version
-  - cookstyle --version
-  - foodcritic --version
 
 script: KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen verify ${INSTANCE}
 
 matrix:
   include:
     - script:
-      - chef exec delivery local all
+      - delivery local all
       env: UNIT_AND_LINT=1

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 # This gemfile provides additional gems for testing and releasing this cookbook
-# It is meant to be installed on top of ChefDK which provides the majority
+# It is meant to be installed on top of ChefDK / Chef Workstationo which provide the majority
 # of the necessary gems for testing this cookbook
 #
 # Run 'chef exec bundle install' to install these dependencies

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -2,6 +2,7 @@ driver:
   name: dokken
   privileged: true # because Docker and SystemD/Upstart
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_license: accept-no-persist
 
 transport:
   name: dokken

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,6 +4,7 @@ driver:
 provisioner:
   name: chef_zero
   deprecations_as_errors: true
+  chef_license: accept-no-persist
 
 verifier:
   name: inspec


### PR DESCRIPTION
Test using Chef Workstation
Add license acceptance
Use Xenial in Travis and remove the old sudo config
Remove redundant version output commands
Execute delivery directly

Signed-off-by: Tim Smith <tsmith@chef.io>